### PR TITLE
Start a cleanup routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,33 @@
 [![GoDoc](https://godoc.org/github.com/gokv/mem?status.svg)](https://godoc.org/github.com/gokv/mem)
 [![Build Status](https://travis-ci.org/gokv/mem.svg?branch=master)](https://travis-ci.org/gokv/mem)
 
-A naïve (read: incomplete) in-memory key-value store implementing `github.com/gokv/store`'s Store interface.
+An in-memory key-value store implementing the `github.com/gokv/store` Store interface.
 
-The focus is on readability and simplicity, rather than on efficiency.
+The focus is on readability and simplicity.
 
-## This package is not ready for production use.
+## Usage
 
-### Known issues:
+```Go
+func main() {
+	s := mem.New()
+	defer s.Close() // close the mem.Store to avoid leaking goroutines
 
-* The expired values are never garbage-collected
+	err := s.SetWithTimeout(context.Background(), "key", Value{p:1}, timeout)
+	if err != nil {
+		panic(err)
+	}
+
+	var v Value // Value is a type that implements json.Marshaler/Unmarshaler
+	ok, err := s.Get(context.Background(), "key", &v)
+
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		panic(errors.New("Value not found!"))
+	}
+
+	fmt.Println("The retrieved value is %q", v)
+}
+```

--- a/cleanup.go
+++ b/cleanup.go
@@ -1,0 +1,43 @@
+package mem
+
+import (
+	"context"
+	"time"
+)
+
+func (s *Store) Cleanup(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	for k, e := range s.m {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		if !e.validAt(now) {
+			delete(s.m, k)
+		}
+	}
+}
+
+func start(fn func(context.Context), timeout, interval time.Duration) (stop func()) {
+	ctx, stop := context.WithCancel(context.Background())
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				fnCtx, fnCancel := context.WithTimeout(ctx, timeout)
+				fn(fnCtx)
+
+				fnCancel()
+				time.Sleep(interval)
+			}
+		}
+	}()
+	return stop
+}

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -1,0 +1,38 @@
+package mem
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type value string
+
+func (s *value) UnmarshalJSON(data []byte) error {
+	*s = value(data)
+	return nil
+}
+
+func (s value) MarshalJSON() (data []byte, err error) {
+	return []byte(s), nil
+}
+
+func TestCleanup(t *testing.T) {
+	s := New()
+	defer s.Close()
+
+	key := "key"
+
+	d := time.Nanosecond
+	s.SetWithTimeout(context.Background(), key, value("wazzup"), d)
+	time.Sleep(d)
+	if _, ok := s.m[key]; !ok {
+		panic(errors.New("expected the value to still be present after short delay"))
+	}
+
+	time.Sleep(time.Millisecond * 1001)
+	if _, ok := s.m[key]; ok {
+		t.Error("expected the value to be garbage collected")
+	}
+}

--- a/store_test.go
+++ b/store_test.go
@@ -150,6 +150,7 @@ func TestStore(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s := mem.New()
+			defer s.Close()
 
 			for _, build := range tc.storeBuilders {
 				build(s)


### PR DESCRIPTION
Set up a goroutine to delete expired entries from the Store.

The routine will execute at most every second, for at most one
millisecond.